### PR TITLE
Fix Next.js build

### DIFF
--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@types/node": "24.0.10",
+    "@types/react": "19.1.8",
     "typescript": "latest"
   }
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "noImplicitAny": true,
@@ -14,11 +18,28 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- include `@types/*` so Next.js doesn't try to install them during build
- adopt the TypeScript settings that Next.js added automatically

## Testing
- `npm run build` in `web`
- `npm run build` in `api`


------
https://chatgpt.com/codex/tasks/task_e_686a8391e204832f98f7dbbeb8303cfa