### PR TITLE
Add community feature with TypeORM

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.e2e-spec\\.ts$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};

--- a/api/package.json
+++ b/api/package.json
@@ -5,18 +5,27 @@
   "scripts": {
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "build": "nest build"
+    "build": "nest build",
+    "test": "jest"
   },
   "dependencies": {
     "@nestjs/common": "latest",
     "@nestjs/core": "latest",
     "@nestjs/platform-express": "latest",
     "reflect-metadata": "latest",
-    "rxjs": "latest"
+    "rxjs": "latest",
+    "@nestjs/typeorm": "latest",
+    "typeorm": "latest",
+    "pg": "latest"
   },
   "devDependencies": {
     "@nestjs/cli": "latest",
     "typescript": "latest",
-    "ts-node": "latest"
+    "ts-node": "latest",
+    "jest": "latest",
+    "ts-jest": "latest",
+    "@types/jest": "latest",
+    "supertest": "latest",
+    "@types/supertest": "latest"
   }
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,9 +1,24 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { Community } from './community/community.entity';
+import { CommunityModule } from './community/community.module';
 
 @Module({
-  imports: [],
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'commune',
+      entities: [Community],
+      synchronize: false,
+    }),
+    CommunityModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/api/src/community/community.controller.ts
+++ b/api/src/community/community.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { CommunityService } from './community.service';
+import { CreateCommunityDto } from './dto/create-community.dto';
+import { Community } from './community.entity';
+
+@Controller('communities')
+export class CommunityController {
+  constructor(private readonly communityService: CommunityService) {}
+
+  @Post()
+  create(@Body() dto: CreateCommunityDto): Promise<Community> {
+    return this.communityService.create(dto);
+  }
+}

--- a/api/src/community/community.e2e-spec.ts
+++ b/api/src/community/community.e2e-spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Community } from './community.entity';
+import { CommunityModule } from './community.module';
+
+describe('CommunityController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [Community],
+          synchronize: true,
+        }),
+        CommunityModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/communities (POST)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/communities')
+      .send({ name: 'Test Community' })
+      .expect(201);
+
+    expect(res.body).toEqual(
+      expect.objectContaining({ id: expect.any(Number), name: 'Test Community' }),
+    );
+  });
+});

--- a/api/src/community/community.entity.ts
+++ b/api/src/community/community.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity({ name: 'communities' })
+export class Community {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/api/src/community/community.module.ts
+++ b/api/src/community/community.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Community } from './community.entity';
+import { CommunityService } from './community.service';
+import { CommunityController } from './community.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Community])],
+  providers: [CommunityService],
+  controllers: [CommunityController],
+})
+export class CommunityModule {}

--- a/api/src/community/community.service.ts
+++ b/api/src/community/community.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Community } from './community.entity';
+import { CreateCommunityDto } from './dto/create-community.dto';
+
+@Injectable()
+export class CommunityService {
+  constructor(
+    @InjectRepository(Community)
+    private readonly communityRepository: Repository<Community>,
+  ) {}
+
+  create(dto: CreateCommunityDto): Promise<Community> {
+    const community = this.communityRepository.create(dto);
+    return this.communityRepository.save(community);
+  }
+}

--- a/api/src/community/dto/create-community.dto.ts
+++ b/api/src/community/dto/create-community.dto.ts
@@ -1,0 +1,3 @@
+export class CreateCommunityDto {
+  name: string;
+}

--- a/api/src/data-source.ts
+++ b/api/src/data-source.ts
@@ -1,0 +1,13 @@
+import { DataSource } from 'typeorm';
+import { Community } from './community/community.entity';
+
+export default new DataSource({
+  type: 'postgres',
+  host: 'localhost',
+  port: 5432,
+  username: 'postgres',
+  password: 'postgres',
+  database: 'commune',
+  entities: [Community],
+  migrations: ['src/migrations/*.ts'],
+});

--- a/api/src/migrations/1715619180000-CreateCommunityTable.ts
+++ b/api/src/migrations/1715619180000-CreateCommunityTable.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCommunityTable1715619180000 implements MigrationInterface {
+  name = 'CreateCommunityTable1715619180000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "communities" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, CONSTRAINT "PK_communities_id" PRIMARY KEY ("id"))`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "communities"`);
+  }
+}


### PR DESCRIPTION
## Summary
- install TypeORM, PG and Nest integration
- setup TypeORM and Community module
- implement REST endpoint to create communities
- provide initial migration for the communities table
- add e2e test for creating a community

## Testing
- `npm run build` *(fails: nest not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9b5399bc832f8503cde1194bd666