### PR TITLE
Add GET community endpoint with tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,10 @@ When adding new code:
 - Keep features independent; avoid spreading feature logic across unrelated modules.
 - New slices should contain everything they need (handlers, models, tests, etc.) within the same feature folder.
 
+## Testing
+
+All new functionality must include tests. For API endpoints, write integration
+tests that exercise the actual HTTP routes. Pull requests without appropriate
+test coverage may be rejected.
+
 Please ensure pull requests respect these guidelines.

--- a/api/src/community/community.controller.ts
+++ b/api/src/community/community.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { CommunityService } from './community.service';
 import { CreateCommunityDto } from './dto/create-community.dto';
 import { Community } from './community.entity';
@@ -10,5 +10,10 @@ export class CommunityController {
   @Post()
   create(@Body() dto: CreateCommunityDto): Promise<Community> {
     return this.communityService.create(dto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<Community | null> {
+    return this.communityService.findOne(id);
   }
 }

--- a/api/src/community/community.e2e-spec.ts
+++ b/api/src/community/community.e2e-spec.ts
@@ -7,6 +7,7 @@ import { CommunityModule } from './community.module';
 
 describe('CommunityController (e2e)', () => {
   let app: INestApplication;
+  let createdId: number;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -39,5 +40,14 @@ describe('CommunityController (e2e)', () => {
     expect(res.body).toEqual(
       expect.objectContaining({ id: expect.any(Number), name: 'Test Community' }),
     );
+    createdId = res.body.id;
+  });
+
+  it('/communities/:id (GET)', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/communities/${createdId}`)
+      .expect(200);
+
+    expect(res.body).toEqual({ id: createdId, name: 'Test Community' });
   });
 });

--- a/api/src/community/community.service.ts
+++ b/api/src/community/community.service.ts
@@ -15,4 +15,8 @@ export class CommunityService {
     const community = this.communityRepository.create(dto);
     return this.communityRepository.save(community);
   }
+
+  findOne(id: number): Promise<Community | null> {
+    return this.communityRepository.findOneBy({ id });
+  }
 }


### PR DESCRIPTION
## Summary
- implement endpoint to fetch a single community
- add integration tests for new route
- document testing expectations in CONTRIBUTING

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa8153ae0832fbf3d43c40411b9d9