### PR TITLE
docs: remove npm exec guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ be managed together.
 ## Development
 
 Backend development uses the NestJS framework and Jest for testing.
-Run their CLI commands normally (e.g. `nest start`, `jest`), as they are
-installed as part of the development setup.
 
 Run `npm test` from the repository root to execute the `test` script in
 all workspaces. It leverages npm's workspace mode to run each package's

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ A monorepo containing both the frontend and backend applications.
 
 - `web` – Next.js frontend
 - `api` – NestJS backend
+
+This repository is configured as an **npm workspace**. The root
+`package.json` lists both `api` and `web` as workspaces so dependencies can
+be managed together.
+
+## Development
+
+Backend development uses the NestJS framework and Jest for testing.
+Run their CLI commands normally (e.g. `nest start`, `jest`), as they are
+installed as part of the development setup.
+
+Run `npm test` from the repository root to execute the `test` script in
+all workspaces. It leverages npm's workspace mode to run each package's
+tests if the script is present.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "commune-manager",
+  "private": true,
+  "workspaces": [
+    "api",
+    "web"
+  ],
+  "scripts": {
+    "test": "npm --workspaces --if-present test"
+  }
+}


### PR DESCRIPTION
## Summary
- remove guidance about using `npm exec` for Nest and Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa545c6f4832fa878a34e6ec8485a