### PR TITLE
Use DATABASE_URL for DB connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,8 @@
     "rxjs": "latest",
     "@nestjs/typeorm": "latest",
     "typeorm": "latest",
-    "pg": "latest"
+    "pg": "latest",
+    "zod": "latest"
   },
   "devDependencies": {
     "@nestjs/cli": "latest",
@@ -26,6 +27,8 @@
     "ts-jest": "latest",
     "@types/jest": "latest",
     "supertest": "latest",
-    "@types/supertest": "latest"
+    "@types/supertest": "latest",
+    "sqlite3": "latest",
+    "@nestjs/testing": "latest"
   }
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -4,16 +4,13 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { Community } from './community/community.entity';
 import { CommunityModule } from './community/community.module';
+import { DATABASE_URL } from './config/env';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: 'localhost',
-      port: 5432,
-      username: 'postgres',
-      password: 'postgres',
-      database: 'commune',
+      url: DATABASE_URL,
       entities: [Community],
       synchronize: false,
     }),

--- a/api/src/config/env.e2e-spec.ts
+++ b/api/src/config/env.e2e-spec.ts
@@ -1,0 +1,21 @@
+describe('env validation', () => {
+  const originalEnv = process.env.DATABASE_URL;
+
+  afterEach(() => {
+    process.env.DATABASE_URL = originalEnv;
+    jest.resetModules();
+  });
+
+  it('throws when DATABASE_URL is missing', () => {
+    delete process.env.DATABASE_URL;
+    jest.resetModules();
+    expect(() => require('./env')).toThrow();
+  });
+
+  it('returns DATABASE_URL when present', () => {
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+    jest.resetModules();
+    const env = require('./env');
+    expect(env.DATABASE_URL).toBe('postgres://user:pass@localhost:5432/db');
+  });
+});

--- a/api/src/config/env.ts
+++ b/api/src/config/env.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().nonempty(),
+});
+
+export const env = envSchema.parse(process.env);
+
+export const DATABASE_URL = env.DATABASE_URL;
+

--- a/api/src/data-source.ts
+++ b/api/src/data-source.ts
@@ -1,13 +1,10 @@
 import { DataSource } from 'typeorm';
 import { Community } from './community/community.entity';
+import { DATABASE_URL } from './config/env';
 
 export default new DataSource({
   type: 'postgres',
-  host: 'localhost',
-  port: 5432,
-  username: 'postgres',
-  password: 'postgres',
-  database: 'commune',
+  url: DATABASE_URL,
   entities: [Community],
   migrations: ['src/migrations/*.ts'],
 });


### PR DESCRIPTION
## Summary
- validate environment variables with zod
- use `DATABASE_URL` for Postgres connection
- test env validation logic
- ignore workspace lockfile and node_modules

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ab718715c832f8670952685e460de