### PR TITLE
Implement user profiles with avatar upload

### DIFF
--- a/web/instant.schema.ts
+++ b/web/instant.schema.ts
@@ -6,6 +6,10 @@ const _schema = i.schema({
       name: i.string().indexed(),
     }),
     members: i.entity({}),
+    profiles: i.entity({
+      name: i.string(),
+      displayName: i.string(),
+    }),
   },
   links: {
     memberUser: {
@@ -15,6 +19,14 @@ const _schema = i.schema({
     communityMembers: {
       forward: { on: 'communities', has: 'many', label: 'members' },
       reverse: { on: 'members', has: 'many', label: 'communities' },
+    },
+    profileUser: {
+      forward: { on: 'profiles', has: 'one', label: '$user' },
+      reverse: { on: '$users' as any, has: 'one', label: 'profile' },
+    },
+    profileAvatar: {
+      forward: { on: 'profiles', has: 'one', label: 'avatar' },
+      reverse: { on: '$files' as any, has: 'one', label: 'profile' },
     },
   },
 });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,8 @@ export default function Page() {
       <Link href="/communities">View Communities</Link>
       <br />
       <Link href="/communities/invite">Invite Member</Link>
+      <br />
+      <Link href="/profile">My Profile</Link>
     </div>
   );
 }

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+import { useEffect, useState, FormEvent } from 'react';
+import { db, id } from '@/lib/db';
+
+export default function ProfilePage() {
+  const { user, isLoading: authLoading } = db.useAuth();
+  const query = user
+    ? {
+        profiles: {
+          $: { where: { '$user.id': user.id } },
+          avatar: {},
+        },
+      }
+    : null;
+  const { data, isLoading, error } = db.useQuery(query);
+
+  const profile = data?.profiles?.[0];
+
+  const [name, setName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [avatarUploading, setAvatarUploading] = useState(false);
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name ?? '');
+      setDisplayName(profile.displayName ?? '');
+    }
+  }, [profile]);
+
+  if (authLoading || isLoading) return <p>Loading...</p>;
+  if (!user) return <p>Please sign in.</p>;
+  if (error) return <p>Error loading profile.</p>;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (profile) {
+      await db.transact(db.tx.profiles[profile.id].update({ name, displayName }));
+    } else {
+      const newId = id();
+      await db.transact(
+        db.tx.profiles[newId]
+          .update({ name, displayName })
+          .link({ '$user': user.id })
+      );
+    }
+  }
+
+  async function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !profile) return;
+    setAvatarUploading(true);
+    try {
+      const path = `${user.id}/avatar`;
+      const { data } = await db.storage.uploadFile(path, file);
+      await db.transact(db.tx.profiles[profile.id].link({ avatar: data.id }));
+    } finally {
+      setAvatarUploading(false);
+    }
+  }
+
+  return (
+    <div>
+      <h1>My Profile</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Name: <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <br />
+        <label>
+          Display Name:{' '}
+          <input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+        </label>
+        <br />
+        <button type="submit">Save</button>
+      </form>
+      <div style={{ marginTop: '1rem' }}>
+        <h2>Avatar</h2>
+        {profile?.avatar ? (
+          <img src={profile.avatar.url} alt="avatar" width={120} />
+        ) : (
+          <p>No avatar uploaded.</p>
+        )}
+        <input type="file" accept="image/*" onChange={handleAvatarChange} />
+        {avatarUploading && <p>Uploading...</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `profiles` entity and linking to users and avatar files
- link to profile from home page
- implement profile page with editing and avatar upload

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bed80a8c4832f936e4117ee90e117