### PR TITLE
Redirect user to home after login/register

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { db } from '@/lib/db';
 
 export default function LoginPage() {
@@ -7,6 +8,7 @@ export default function LoginPage() {
   const [code, setCode] = useState('');
   const [step, setStep] = useState<'email' | 'code'>('email');
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const router = useRouter();
 
   async function handleSendCode(e: FormEvent) {
     e.preventDefault();
@@ -25,6 +27,7 @@ export default function LoginPage() {
     setStatus('loading');
     try {
       await db.auth.signInWithMagicCode({ email, code });
+      router.push('/');
     } catch (err) {
       setStatus('error');
     }

--- a/web/src/app/(auth)/register/page.tsx
+++ b/web/src/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { db } from '@/lib/db';
 
 export default function RegisterPage() {
@@ -7,6 +8,7 @@ export default function RegisterPage() {
   const [code, setCode] = useState('');
   const [step, setStep] = useState<'email' | 'code'>('email');
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const router = useRouter();
 
   async function handleSendCode(e: FormEvent) {
     e.preventDefault();
@@ -25,6 +27,7 @@ export default function RegisterPage() {
     setStatus('loading');
     try {
       await db.auth.signInWithMagicCode({ email, code });
+      router.push('/');
     } catch (err) {
       setStatus('error');
     }


### PR DESCRIPTION
## Summary
- navigate to the home page after logging in
- navigate to the home page after registering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c2bcec1f8832fa0ae2462374f37b7